### PR TITLE
키워드 CRUD 서비스 리뉴얼

### DIFF
--- a/src/main/java/in/koala/controller/KeywordController.java
+++ b/src/main/java/in/koala/controller/KeywordController.java
@@ -20,13 +20,13 @@ public class KeywordController {
 
     private final KeywordService keywordService;
     
-//    @Xss
-//    @Auth
-//    @ApiOperation(value ="키워드 조회" , notes = "사용자가 지정한 키워드를 조회한다." , authorizations = @Authorization(value = "Bearer +accessToken"))
-//    @GetMapping(value = "/keyword")
-//    public ResponseEntity<List<Keyword>> myKeywordList(){
-//        return new ResponseEntity(keywordService.myKeywordList(), HttpStatus.OK);
-//    }
+    @Xss
+    @Auth
+    @ApiOperation(value ="키워드 조회" , notes = "사용자가 지정한 키워드를 조회한다." , authorizations = @Authorization(value = "Bearer +accessToken"))
+    @GetMapping(value = "/keyword")
+    public ResponseEntity<List<Keyword>> myKeywordList(){
+        return new ResponseEntity(keywordService.myKeywordList(), HttpStatus.OK);
+    }
 
     @Xss
     @Auth

--- a/src/main/java/in/koala/controller/KeywordController.java
+++ b/src/main/java/in/koala/controller/KeywordController.java
@@ -20,39 +20,37 @@ public class KeywordController {
 
     private final KeywordService keywordService;
     
-    @Xss
-    @Auth
-    @ApiOperation(value ="키워드 조회" , notes = "사용자가 지정한 키워드를 조회한다." , authorizations = @Authorization(value = "Bearer +accessToken"))
-    @GetMapping(value = "/keyword")
-    public ResponseEntity<List<Keyword>> myKeywordList(){
-        return new ResponseEntity(keywordService.myKeywordList(), HttpStatus.OK);
-    }
+//    @Xss
+//    @Auth
+//    @ApiOperation(value ="키워드 조회" , notes = "사용자가 지정한 키워드를 조회한다." , authorizations = @Authorization(value = "Bearer +accessToken"))
+//    @GetMapping(value = "/keyword")
+//    public ResponseEntity<List<Keyword>> myKeywordList(){
+//        return new ResponseEntity(keywordService.myKeywordList(), HttpStatus.OK);
+//    }
 
 
     @Xss
     @Auth
-    @ApiOperation(value ="키워드 삽입" , notes = "사용자가 지정한 키워드를 등록한다." , authorizations = @Authorization(value = "Bearer +accessToken"))
+    @ApiOperation(value ="키워드 추가" , notes = "사용자가 지정한 키워드를 등록한다." , authorizations = @Authorization(value = "Bearer +accessToken"))
     @PostMapping(value = "/keyword")
-    public void registerKeyword(@RequestParam(name = "keyword") String keyword,
-                                @RequestParam(name = "site") short site,
-                                @RequestParam(name = "isImportant") boolean isImportant){
-        keywordService.registerKeyword(keyword, site, isImportant);
+    public void registerKeyword(@RequestBody Keyword keyword){
+        keywordService.registerKeyword(keyword);
     }
 
-    @Xss
-    @Auth
-    @ApiOperation(value = "키워드 삭제", notes = "사용자가 지정한 키워드를 삭제한다.", authorizations = @Authorization(value = "Bearer +accessToken"))
-    @PatchMapping(value = "/keyword")
-    public void deleteKeyword(@RequestParam(name = "keyword-id") String keywordId){
-        keywordService.deleteKeyword(keywordId);
-    }
+//    @Xss
+//    @Auth
+//    @ApiOperation(value = "키워드 삭제", notes = "사용자가 지정한 키워드를 삭제한다.", authorizations = @Authorization(value = "Bearer +accessToken"))
+//    @PatchMapping(value = "/keyword")
+//    public void deleteKeyword(@RequestParam(name = "keyword-id") String keywordId){
+//        keywordService.deleteKeyword(keywordId);
+//    }
 
-    @Xss
-    @Auth
-    @ApiOperation(value = "키워드 수정", notes = "사용자가 지정한 키워드를 수정한다.", authorizations = @Authorization(value = "Bearer +accessToken"))
-    @PutMapping(value = "/keyword")
-    public void modifyKeyword(@RequestParam(name = "keyword-id") String keywordId,
-                              @RequestParam(name = "keyword-name") String keywordName){
-        keywordService.modifyKeyword(keywordId, keywordName);
-    }
+//    @Xss
+//    @Auth
+//    @ApiOperation(value = "키워드 수정", notes = "사용자가 지정한 키워드를 수정한다.", authorizations = @Authorization(value = "Bearer +accessToken"))
+//    @PutMapping(value = "/keyword")
+//    public void modifyKeyword(@RequestParam(name = "keyword-id") String keywordId,
+//                              @RequestParam(name = "keyword-name") String keywordName){
+//        keywordService.modifyKeyword(keywordId, keywordName);
+//    }
 }

--- a/src/main/java/in/koala/controller/KeywordController.java
+++ b/src/main/java/in/koala/controller/KeywordController.java
@@ -28,7 +28,6 @@ public class KeywordController {
 //        return new ResponseEntity(keywordService.myKeywordList(), HttpStatus.OK);
 //    }
 
-
     @Xss
     @Auth
     @ApiOperation(value ="키워드 추가" , notes = "사용자가 지정한 키워드를 등록한다." , authorizations = @Authorization(value = "Bearer +accessToken"))
@@ -37,20 +36,21 @@ public class KeywordController {
         keywordService.registerKeyword(keyword);
     }
 
-//    @Xss
-//    @Auth
-//    @ApiOperation(value = "키워드 삭제", notes = "사용자가 지정한 키워드를 삭제한다.", authorizations = @Authorization(value = "Bearer +accessToken"))
-//    @PatchMapping(value = "/keyword")
-//    public void deleteKeyword(@RequestParam(name = "keyword-id") String keywordId){
-//        keywordService.deleteKeyword(keywordId);
-//    }
+    @Xss
+    @Auth
+    @ApiOperation(value = "키워드 삭제", notes = "사용자가 지정한 키워드를 삭제한다.", authorizations = @Authorization(value = "Bearer +accessToken"))
+    @PatchMapping(value = "/keyword")
+    public void deleteKeyword(@RequestParam(name = "keyword-name") String keywordName){
+        keywordService.deleteKeyword(keywordName);
+    }
 
-//    @Xss
-//    @Auth
-//    @ApiOperation(value = "키워드 수정", notes = "사용자가 지정한 키워드를 수정한다.", authorizations = @Authorization(value = "Bearer +accessToken"))
-//    @PutMapping(value = "/keyword")
-//    public void modifyKeyword(@RequestParam(name = "keyword-id") String keywordId,
-//                              @RequestParam(name = "keyword-name") String keywordName){
-//        keywordService.modifyKeyword(keywordId, keywordName);
-//    }
+    @Xss
+    @Auth
+    @ApiOperation(value = "키워드 수정", notes = "사용자가 지정한 키워드를 수정한다.", authorizations = @Authorization(value = "Bearer +accessToken"))
+    @PutMapping(value = "/keyword")
+    public void modifyKeyword(@RequestParam(name = "keyword-name") String keywordName,
+                              @RequestBody Keyword keyword){
+        keywordService.modifyKeyword(keywordName, keyword);
+    }
+
 }

--- a/src/main/java/in/koala/controller/KeywordPushController.java
+++ b/src/main/java/in/koala/controller/KeywordPushController.java
@@ -2,18 +2,13 @@ package in.koala.controller;
 
 import in.koala.annotation.Auth;
 import in.koala.annotation.Xss;
-import in.koala.domain.Crawling;
 import in.koala.service.KeywordPushService;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.Authorization;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -25,7 +20,7 @@ public class KeywordPushController {
     @Auth
     @ApiOperation(value ="키워드 푸쉬 메세지" , notes = "사용자가 지정한 키워드를 크롤링한 데이터에서 찾아 알림한다." , authorizations = @Authorization(value = "Bearer +accessToken"))
     @GetMapping(value = "/fcm/keyword")
-    public ResponseEntity<List<Crawling>> pushKeyword(@RequestParam(name = "device-token") String deviceToken){
-        return new ResponseEntity<List<Crawling>>(keywordPushService.pushKeyword(deviceToken), HttpStatus.OK);
+    public void pushKeyword(@RequestParam(name = "device-token") String deviceToken){
+        keywordPushService.pushKeyword(deviceToken);
     }
 }

--- a/src/main/java/in/koala/domain/Keyword.java
+++ b/src/main/java/in/koala/domain/Keyword.java
@@ -1,6 +1,8 @@
 package in.koala.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.annotations.ApiModelProperty;
 import lombok.Getter;
 import lombok.Setter;
@@ -10,6 +12,7 @@ import java.util.List;
 
 @Getter
 @Setter
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Keyword {
 
     @ApiModelProperty(hidden = true)
@@ -20,8 +23,14 @@ public class Keyword {
 
     private String name;
     private List<String> siteList;
+
+    @JsonIgnore
     private short isImportant;
+
+    @JsonIgnore
     private short alarmMode;
+
+    @JsonIgnore
     private int alarmCycle;
 
     @ApiModelProperty(hidden = true)
@@ -30,6 +39,7 @@ public class Keyword {
     @ApiModelProperty(hidden = true)
     private Timestamp updatedAt;
 
+    @JsonIgnore
     @ApiModelProperty(hidden = true)
     private short isDeleted;
 }

--- a/src/main/java/in/koala/domain/Keyword.java
+++ b/src/main/java/in/koala/domain/Keyword.java
@@ -18,10 +18,7 @@ public class Keyword {
     @ApiModelProperty(hidden = true)
     private Long userId;
 
-    @ApiModelProperty(hidden = true)
-    private Long keywordId;
-
-    private String keywordName;
+    private String name;
     private List<String> siteList;
     private short isImportant;
     private short alarmMode;
@@ -34,5 +31,5 @@ public class Keyword {
     private Timestamp updatedAt;
 
     @ApiModelProperty(hidden = true)
-    private short is_deleted;
+    private short isDeleted;
 }

--- a/src/main/java/in/koala/domain/Keyword.java
+++ b/src/main/java/in/koala/domain/Keyword.java
@@ -1,27 +1,38 @@
 package in.koala.domain;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import lombok.Setter;
+
+import java.sql.Timestamp;
+import java.util.List;
 
 @Getter
 @Setter
 public class Keyword {
 
+    @ApiModelProperty(hidden = true)
     private Long id;
-    private String keyword;
-    private short site;
+
+    @ApiModelProperty(hidden = true)
+    private Long userId;
+
+    @ApiModelProperty(hidden = true)
+    private Long keywordId;
+
+    private String keywordName;
+    private List<String> siteList;
     private short isImportant;
+    private short alarmMode;
+    private int alarmCycle;
 
-    public Keyword(String keyword, short site){
-        this.keyword = keyword;
-        this.site = site;
-    }
+    @ApiModelProperty(hidden = true)
+    private Timestamp createdAt;
 
-    public Keyword(Long id, String keyword, short site, short isImportant){
-        this.id = id;
-        this.keyword = keyword;
-        this.site = site;
-    }
+    @ApiModelProperty(hidden = true)
+    private Timestamp updatedAt;
 
+    @ApiModelProperty(hidden = true)
+    private short is_deleted;
 }

--- a/src/main/java/in/koala/enums/ErrorMessage.java
+++ b/src/main/java/in/koala/enums/ErrorMessage.java
@@ -73,7 +73,12 @@ public enum ErrorMessage {
 	/**
 	 * FCM Push Notification
 	 */
-	FAILED_TO_SEND_NOTIFICATION(400, "알림 발송에 실패하였습니다.")
+	FAILED_TO_SEND_NOTIFICATION(400, "알림 발송에 실패하였습니다."),
+
+	/**
+	 * Keyword
+	 */
+	DUPLICATED_KEYWORD_EXCEPTION(500, "이미 등록하신 키워드입니다.")
 	;
 
 

--- a/src/main/java/in/koala/enums/ErrorMessage.java
+++ b/src/main/java/in/koala/enums/ErrorMessage.java
@@ -66,7 +66,14 @@ public enum ErrorMessage {
 	/**
 	 * Crawling
 	 */
-	UNABLE_CONNECT_TO_URL(300, "해당 웹 사이트에 접속할 수 없습니다.")
+	UNABLE_CONNECT_TO_PORTAL(300, "아우누리 웹 사이트에 접속할 수 없습니다."),
+	UNABLE_CONNECT_TO_DORM(301, "아우미르 웹 사이트에 접속할 수 없습니다."),
+	UNABLE_CONNECT_TO_YOUTUBE(302, "유튜브 API 호출이 불가 합니다."),
+
+	/**
+	 * FCM Push Notification
+	 */
+	FAILED_TO_SEND_NOTIFICATION(400, "알림 발송에 실패하였습니다.")
 	;
 
 

--- a/src/main/java/in/koala/exception/KeywordException.java
+++ b/src/main/java/in/koala/exception/KeywordException.java
@@ -1,0 +1,13 @@
+package in.koala.exception;
+
+import in.koala.enums.ErrorMessage;
+
+public class KeywordException extends NonCriticalException{
+
+    public KeywordException(String className, ErrorMessage errorMessage) {
+        super(className, errorMessage);
+    }
+    public KeywordException(ErrorMessage errorMessage) {
+        super(errorMessage);
+    }
+}

--- a/src/main/java/in/koala/exception/KeywordPushException.java
+++ b/src/main/java/in/koala/exception/KeywordPushException.java
@@ -1,0 +1,13 @@
+package in.koala.exception;
+
+import in.koala.enums.ErrorMessage;
+
+public class KeywordPushException extends CriticalException{
+
+    public KeywordPushException(String className, ErrorMessage errorMessage) {
+        super(className, errorMessage);
+    }
+    public KeywordPushException(ErrorMessage errorMessage) {
+        super(errorMessage);
+    }
+}

--- a/src/main/java/in/koala/mapper/KeywordMapper.java
+++ b/src/main/java/in/koala/mapper/KeywordMapper.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 @Repository
 public interface KeywordMapper {
@@ -13,11 +14,14 @@ public interface KeywordMapper {
 
     Long checkDuplicateUsersKeyword(Keyword keyword);
     int insertUsersKeyword(Keyword keyword);
-    void insertUsersKeywordSite(Map map);
+    int insertUsersKeywordSite(Map map);
 
     List<Keyword> myKeywordList(Long userId);
 
     int deleteKeyword(Map map);
 
+    Set getKeywordSite(Map map);
+    Long getKeywordId(Map map);
+    int modifyKeywordSite(Map map);
     int modifyKeyword(Map map);
 }

--- a/src/main/java/in/koala/mapper/KeywordMapper.java
+++ b/src/main/java/in/koala/mapper/KeywordMapper.java
@@ -1,6 +1,7 @@
 package in.koala.mapper;
 
 import in.koala.domain.Keyword;
+import org.apache.ibatis.annotations.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -9,14 +10,14 @@ import java.util.Map;
 @Repository
 public interface KeywordMapper {
 
-    Long checkDuplicateKeyword(Keyword keyword);
-    Long insertKeyword(Keyword keyword);
 
     Long checkDuplicateUsersKeyword(Keyword keyword);
     int insertUsersKeyword(Keyword keyword);
+    void insertUsersKeywordSite(Map map);
 
     List<Keyword> myKeywordList(Long userId);
 
     int deleteKeyword(Map map);
+
     int modifyKeyword(Map map);
 }

--- a/src/main/java/in/koala/mapper/KeywordMapper.java
+++ b/src/main/java/in/koala/mapper/KeywordMapper.java
@@ -8,9 +8,15 @@ import java.util.Map;
 
 @Repository
 public interface KeywordMapper {
+
+    Long checkDuplicateKeyword(Keyword keyword);
+    Long insertKeyword(Keyword keyword);
+
+    Long checkDuplicateUsersKeyword(Keyword keyword);
+    int insertUsersKeyword(Keyword keyword);
+
     List<Keyword> myKeywordList(Long userId);
-    int insertKeyword(Keyword keyword);
-    int insertUsersKeyword(Map map);
+
     int deleteKeyword(Map map);
     int modifyKeyword(Map map);
 }

--- a/src/main/java/in/koala/service/KeywordPushService.java
+++ b/src/main/java/in/koala/service/KeywordPushService.java
@@ -1,10 +1,6 @@
 package in.koala.service;
 
-import in.koala.domain.Crawling;
-
-import java.util.List;
-
 public interface KeywordPushService {
 
-    List<Crawling> pushKeyword(String deviceToken);
+    void pushKeyword(String deviceToken);
 }

--- a/src/main/java/in/koala/service/KeywordService.java
+++ b/src/main/java/in/koala/service/KeywordService.java
@@ -8,5 +8,5 @@ public interface KeywordService {
     List<Keyword> myKeywordList();
     void registerKeyword(Keyword keyword);
     void deleteKeyword(String keywordId);
-    void modifyKeyword(String keywordId, String keywordName);
+    void modifyKeyword(String keywordName, Keyword keyword);
 }

--- a/src/main/java/in/koala/service/KeywordService.java
+++ b/src/main/java/in/koala/service/KeywordService.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public interface KeywordService {
     List<Keyword> myKeywordList();
-    void registerKeyword(String keyword, short site, boolean isImportant);
+    void registerKeyword(Keyword keyword);
     void deleteKeyword(String keywordId);
     void modifyKeyword(String keywordId, String keywordName);
 }

--- a/src/main/java/in/koala/serviceImpl/KeywordPushServiceImpl.java
+++ b/src/main/java/in/koala/serviceImpl/KeywordPushServiceImpl.java
@@ -1,7 +1,8 @@
 package in.koala.serviceImpl;
 
-import in.koala.domain.Crawling;
 import in.koala.domain.fcm.TokenMessage;
+import in.koala.enums.ErrorMessage;
+import in.koala.exception.KeywordPushException;
 import in.koala.mapper.KeywordPushMapper;
 import in.koala.service.KeywordPushService;
 import in.koala.service.UserService;
@@ -21,23 +22,21 @@ public class KeywordPushServiceImpl implements KeywordPushService {
     private final KeywordPushMapper keywordPushMapper;
 
     @Override
-    public List<Crawling> pushKeyword(String deviceToken) {
+    public void pushKeyword(String deviceToken) {
+
+        Long userId = userService.getLoginUserInfo().getId();
+        List<Map<String, String>> tmp = keywordPushMapper.pushKeyword(userId);
 
         try{
-            Long userId = userService.getLoginUserInfo().getId();
-            System.out.println("user Id : " + userId);
-            List<Map<String, String>> tmp = keywordPushMapper.pushKeyword(userId);
-            System.out.println(tmp);
             for(Map<String, String> map : tmp){
                 String title = map.get("title");
                 String url = map.get("url");
-                System.out.println(title + " " + url);
                 fcmSender.sendMessage(new TokenMessage(title, url, deviceToken));
             }
         }
         catch (Exception e){
-            e.printStackTrace();
+            throw new KeywordPushException(ErrorMessage.FAILED_TO_SEND_NOTIFICATION);
         }
-        return null;
     }
+
 }

--- a/src/main/java/in/koala/serviceImpl/KeywordServiceImpl.java
+++ b/src/main/java/in/koala/serviceImpl/KeywordServiceImpl.java
@@ -9,6 +9,7 @@ import in.koala.service.KeywordService;
 import in.koala.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.Timestamp;
 import java.util.HashMap;
@@ -17,6 +18,7 @@ import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class KeywordServiceImpl implements KeywordService {
 
     private final KeywordMapper keywordMapper;
@@ -32,45 +34,44 @@ public class KeywordServiceImpl implements KeywordService {
     public void registerKeyword(Keyword keyword) {
 
         Long userId = userService.getLoginUserInfo().getId();
+        Timestamp createdAt = new Timestamp(System.currentTimeMillis());
+
         keyword.setUserId(userId);
-
-        Long keywordId = keywordMapper.checkDuplicateKeyword(keyword);
-        if(keywordId == null) {
-            keywordMapper.insertKeyword(keyword);
-        }
-        else{
-            keyword.setKeywordId(keywordId);
-        }
-
-        keyword.setCreatedAt(new Timestamp(System.currentTimeMillis()));
+        keyword.setCreatedAt(createdAt);
 
         if(keywordMapper.checkDuplicateUsersKeyword(keyword) != null){
             throw new KeywordException(ErrorMessage.DUPLICATED_KEYWORD_EXCEPTION);
         }
         else{
-            if(1 == keywordMapper.insertUsersKeyword(keyword))
-                System.out.println("성공");
-            else
-                System.out.println("실패");
+            keywordMapper.insertUsersKeyword(keyword);
+            Map<String, Object> map = new HashMap<>();
+            map.put("keywordId", keyword.getId());
+            map.put("siteList", keyword.getSiteList());
+            map.put("createdAt", keyword.getCreatedAt());
+            keywordMapper.insertUsersKeywordSite(map);
         }
     }
 
     @Override
-    public void deleteKeyword(String keywordId) {
+    public void deleteKeyword(String keywordName) {
         Long userId = userService.getLoginUserInfo().getId();
         Map<String, Object> map = new HashMap<String, Object>();
-        map.put("user_id", userId);
-        map.put("keyword_id", keywordId);
+        map.put("userId", userId);
+        map.put("name", keywordName);
         keywordMapper.deleteKeyword(map);
     }
 
     @Override
-    public void modifyKeyword(String keywordId, String keywordName) {
+    public void modifyKeyword(String keywordName, Keyword keyword) {
         Long userId = userService.getLoginUserInfo().getId();
+        Timestamp updatedAt = new Timestamp(System.currentTimeMillis());
+        keyword.setUpdatedAt(updatedAt);
+
         Map<String, Object> map = new HashMap<String, Object>();
-        map.put("keyword_id", keywordId);
+        map.put("user_id", userId);
         map.put("keyword_name", keywordName);
-        System.out.println(map);
-        keywordMapper.deleteKeyword(map);
+        map.put("modifiedKeyword", keyword);
+
+        keywordMapper.modifyKeyword(map);
     }
 }

--- a/src/main/resources/mapper/KeywordMapper.xml
+++ b/src/main/resources/mapper/KeywordMapper.xml
@@ -9,17 +9,29 @@
         WHERE uk.user_id = #{userId}
     </select>
 
-    <insert id="insertKeyword" parameterType="in.koala.domain.Keyword">
-        INSERT INTO keyword (name, site)
-        VALUES (#{keyword}, #{site})
-        <selectKey keyProperty="id" resultType="Long">
+    <select id="checkDuplicateKeyword" parameterType="in.koala.domain.Keyword" resultType="java.lang.Long">
+        SELECT id
+        FROM keyword
+        WHERE name = #{keywordName}
+    </select>
+
+    <insert id="insertKeyword" parameterType="string">
+        INSERT INTO keyword (name)
+        VALUES (#{keywordName})
+        <selectKey keyProperty="keywordId" resultType="Long" order="AFTER">
             SELECT LAST_INSERT_ID()
         </selectKey>
     </insert>
 
-    <insert id="insertUsersKeyword" useGeneratedKeys="true" parameterType="java.util.Map" keyProperty="id">
-        INSERT INTO user_keyword (user_id, keyword_id, is_important)
-        VALUES (#{user_id}, #{keyword_id}, #{is_important})
+    <select id="checkDuplicateUsersKeyword" parameterType="in.koala.domain.Keyword" resultType="java.lang.Long">
+        SELECT id
+        FROM user_keyword
+        WHERE user_id = #{userId} AND keyword_id = #{keywordId}
+    </select>
+
+    <insert id="insertUsersKeyword" useGeneratedKeys="true" parameterType="in.koala.domain.Keyword" keyProperty="id">
+        INSERT INTO user_keyword (user_id, keyword_id, is_important, alarm_mode, alarm_cycle, created_at)
+        VALUES (#{userId}, #{keywordId}, #{isImportant}, #{alarmMode}, #{alarmCycle}, #{createdAt})
     </insert>
 
     <update id="deleteKeyword" parameterType="java.util.Map">

--- a/src/main/resources/mapper/KeywordMapper.xml
+++ b/src/main/resources/mapper/KeywordMapper.xml
@@ -9,42 +9,50 @@
         WHERE uk.user_id = #{userId}
     </select>
 
-    <select id="checkDuplicateKeyword" parameterType="in.koala.domain.Keyword" resultType="java.lang.Long">
+    <select id="checkDuplicateUsersKeyword" parameterType="in.koala.domain.Keyword" resultType="java.lang.Long">
         SELECT id
         FROM keyword
-        WHERE name = #{keywordName}
+        WHERE user_id = #{userId} AND name = #{name}
     </select>
 
-    <insert id="insertKeyword" parameterType="string">
-        INSERT INTO keyword (name)
-        VALUES (#{keywordName})
-        <selectKey keyProperty="keywordId" resultType="Long" order="AFTER">
+    <insert id="insertUsersKeyword" parameterType="in.koala.domain.Keyword">
+        INSERT INTO keyword (user_id, name, is_important, alarm_mode, alarm_cycle, created_at)
+        VALUES (#{userId}, #{name}, #{isImportant}, #{alarmMode}, #{alarmCycle}, #{createdAt})
+        <selectKey keyProperty="id" resultType="Long" order="AFTER">
             SELECT LAST_INSERT_ID()
         </selectKey>
     </insert>
 
-    <select id="checkDuplicateUsersKeyword" parameterType="in.koala.domain.Keyword" resultType="java.lang.Long">
-        SELECT id
-        FROM user_keyword
-        WHERE user_id = #{userId} AND keyword_id = #{keywordId}
-    </select>
-
-    <insert id="insertUsersKeyword" useGeneratedKeys="true" parameterType="in.koala.domain.Keyword" keyProperty="id">
-        INSERT INTO user_keyword (user_id, keyword_id, is_important, alarm_mode, alarm_cycle, created_at)
-        VALUES (#{userId}, #{keywordId}, #{isImportant}, #{alarmMode}, #{alarmCycle}, #{createdAt})
+    <insert id="insertUsersKeywordSite" parameterType="java.util.Map">
+        INSERT INTO keyword_site(keyword_id, site_name, created_at)
+        VALUES
+        <foreach item="site" separator=" , " collection="siteList">
+            (
+            #{keywordId},
+            #{site, jdbcType=VARCHAR},
+            #{createdAt}
+            )
+        </foreach>;
     </insert>
 
     <update id="deleteKeyword" parameterType="java.util.Map">
-        UPDATE user_keyword
+        UPDATE keyword
         SET is_deleted = 1
-        WHERE user_id = #{user_id}
-            AND keyword_id = #{keyword_id}
+        WHERE user_id = #{userId}
+            AND name = #{name};
+
+        UPDATE keyword_site
+        SET is_deleted = 1
+        WHERE keyword_id = (
+                SELECT id
+                FROM keyword
+                WHERE user_id = #{userId}
+                  AND name = #{name}
+            );
     </update>
 
     <update id="modifyKeyword" parameterType="java.util.Map">
-        UPDATE keyword
-        SET name = #{keyword_name}
-        WHERE id = #{keyword_id}
+
     </update>
 
 </mapper>

--- a/src/main/resources/mapper/KeywordMapper.xml
+++ b/src/main/resources/mapper/KeywordMapper.xml
@@ -3,10 +3,10 @@
 <mapper namespace="in.koala.mapper.KeywordMapper">
 
     <select id = "myKeywordList" parameterType="java.lang.Long" resultType="in.koala.domain.Keyword">
-        SELECT k.id, k.name as keyword, k.site, uk.is_important as isImportant
-        FROM keyword as k
-            INNER JOIN user_keyword as uk ON uk.keyword_id = k.id
-        WHERE uk.user_id = #{userId}
+        SELECT id, name
+        FROM keyword
+        WHERE user_id = #{userId}
+        ORDER BY created_at;
     </select>
 
     <!--키워드 등록 (1. 유저별로 기존에 등록한 키워드와 지금 등록하려는 키워드가 중복되는지 확인)-->

--- a/src/main/resources/mapper/KeywordMapper.xml
+++ b/src/main/resources/mapper/KeywordMapper.xml
@@ -9,12 +9,14 @@
         WHERE uk.user_id = #{userId}
     </select>
 
+    <!--키워드 등록 (1. 유저별로 기존에 등록한 키워드와 지금 등록하려는 키워드가 중복되는지 확인)-->
     <select id="checkDuplicateUsersKeyword" parameterType="in.koala.domain.Keyword" resultType="java.lang.Long">
         SELECT id
         FROM keyword
         WHERE user_id = #{userId} AND name = #{name}
     </select>
 
+    <!--키워드 등록 (2. 키워드 등록)-->
     <insert id="insertUsersKeyword" parameterType="in.koala.domain.Keyword">
         INSERT INTO keyword (user_id, name, is_important, alarm_mode, alarm_cycle, created_at)
         VALUES (#{userId}, #{name}, #{isImportant}, #{alarmMode}, #{alarmCycle}, #{createdAt})
@@ -23,6 +25,7 @@
         </selectKey>
     </insert>
 
+    <!--키워드 등록 (3. 키워드 별로 구독하는 사이트에 등록)-->
     <insert id="insertUsersKeywordSite" parameterType="java.util.Map">
         INSERT INTO keyword_site(keyword_id, site_name, created_at)
         VALUES
@@ -35,6 +38,7 @@
         </foreach>;
     </insert>
 
+    <!--키워드 삭제 (지금은 멀티쿼리 사용중이나, join문 활용하여 삭제할수 있게 리팩토링 필요)-->
     <update id="deleteKeyword" parameterType="java.util.Map">
         UPDATE keyword
         SET is_deleted = 1
@@ -51,8 +55,47 @@
             );
     </update>
 
-    <update id="modifyKeyword" parameterType="java.util.Map">
+    <select id="getKeywordSite" parameterType="java.util.Map" resultType="java.lang.String">
+        SELECT ks.site_name
+        FROM keyword_site as ks
+        INNER JOIN keyword as k
+        ON k.id = ks.keyword_id
+            AND k.user_id = #{userId}
+            AND k.name = #{name};
+    </select>
 
+    <select id="getKeywordId" parameterType="java.util.Map" resultType="java.lang.Long">
+        SELECT id
+        FROM keyword
+        WHERE user_id = #{userId}
+            AND name = #{name};
+    </select>
+
+    <update id="modifyKeywordSite" parameterType="java.util.Map">
+        <foreach item="site" separator=";" index="index" collection="existingList">
+            UPDATE keyword_site
+            <set>
+                is_deleted = 1
+            </set>
+            WHERE keyword_id = #{keywordId}
+            AND site_name = #{site}
+        </foreach>;
+    </update>
+
+    <update id="modifyKeyword" parameterType="java.util.Map">
+        UPDATE keyword
+        SET name = #{modifiedKeyword.name}, is_important = #{modifiedKeyword.isImportant},
+            alarm_mode = #{modifiedKeyword.alarmMode}, alarm_cycle = #{modifiedKeyword.alarmCycle},
+            updated_at = #{createdAt}
+        WHERE id = (
+            SELECT id
+            FROM (
+                SELECT id
+                FROM keyword
+                WHERE user_id = #{userId}
+                AND name = #{name}
+            ) AS sub_table
+        );
     </update>
 
 </mapper>

--- a/src/main/resources/mapper/UserMapper.xml
+++ b/src/main/resources/mapper/UserMapper.xml
@@ -107,4 +107,5 @@
         ${alias}created_at,
         ${alias}updated_at
     </sql>
+
 </mapper>


### PR DESCRIPTION
키워드 관련 서비스를 전체다 수정하였습니다.

키워드만을 담고 있던 테이블을 제거하고, 키워드 아이디를 이용한 방법을 단순히 키워드 이름만으로 이용할 수 있게 변경하였습니다.