### PR TITLE
solve mysql connector memory leak

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,8 +49,9 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <scope>runtime</scope>
+            <scope>provided</scope>
         </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-tomcat</artifactId>

--- a/src/main/java/in/koala/controller/UserController.java
+++ b/src/main/java/in/koala/controller/UserController.java
@@ -155,7 +155,7 @@ public class UserController {
 
     @Auth
     @GetMapping(value="/auth-check")
-    @ApiOperation(value="이메일 인증 여부 확인", notes="해당 계정의 학교 인증 여부를 확인하는 API", authorizations = @Authorization(value = "Bearer +accessToken"))
+    @ApiOperation(value="학교 인증 여부 확인", notes="해당 계정의 학교 인증 여부를 확인하는 API", authorizations = @Authorization(value = "Bearer +accessToken"))
     public ResponseEntity checkAuth(){
         userService.isEmailCertification();
         return new ResponseEntity(CustomBody.of("인증 완료", HttpStatus.OK), HttpStatus.OK);


### PR DESCRIPTION
배포시 tomcat이 죽는 문제를 해결하기 위해 pom.xml의 mysql connector의 scope를 provided로 변경 