### PR TITLE
키워드 - 알림 삭제 API 수정, 유튜브 크롤링 오류 수정

### DIFF
--- a/src/main/java/in/koala/controller/KeywordController.java
+++ b/src/main/java/in/koala/controller/KeywordController.java
@@ -100,8 +100,8 @@ public class KeywordController {
     @Auth
     @ApiOperation(value = "키워드 목록 페이지 - 알림 삭제", notes = "키워드 목록에서 하나의 키워드를 선택한 후 나온 알림에 대해서 \n 클릭시 알림 삭제", authorizations = @Authorization(value = "Bearer +accessToken"))
     @PatchMapping(value = "/keyword/list/notice")
-    public void deleteNotice(@RequestParam(name = "notice-id") String noticeId){
-        keywordService.deletedNotice(noticeId);
+    public void deleteNotice(@RequestParam(name = "notice-id") List<Integer> noticeList){
+        keywordService.deletedNotice(noticeList);
     }
 
     @Xss

--- a/src/main/java/in/koala/mapper/KeywordMapper.java
+++ b/src/main/java/in/koala/mapper/KeywordMapper.java
@@ -27,7 +27,7 @@ public interface KeywordMapper {
     List<Integer> getSiteList(Long userId, String keywordName);
 
     Integer noticeRead(String noticeId);
-    Integer deleteNotice(String noticeId);
+    Integer deleteNotice(List<Integer> noticeList);
 
     int deleteKeyword(Long userId, String keywordName);
 

--- a/src/main/java/in/koala/service/KeywordService.java
+++ b/src/main/java/in/koala/service/KeywordService.java
@@ -14,7 +14,7 @@ public interface KeywordService {
     List<Notice> getSearchNotice(String keywordName, String site, String word);
 
     Boolean noticeRead(String noticeId);
-    void deletedNotice(String noticeId);
+    void deletedNotice(List<Integer> noticeList);
 
     List<String> searchKeyword(String keyword);
 

--- a/src/main/java/in/koala/serviceImpl/CrawlingServiceImpl.java
+++ b/src/main/java/in/koala/serviceImpl/CrawlingServiceImpl.java
@@ -195,10 +195,13 @@ public class CrawlingServiceImpl implements CrawlingService {
     @Override
     public Boolean youtubeCrawling(Timestamp crawlingAt) throws Exception {
 
+        Timestamp lateylyCrawlingTime = crawlingMapper.getLatelyCrawlingTime();
+
         SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
-        Date tmp = new Date();
-        String now = format.format(tmp);
+
         List<Crawling> crawlingList = new ArrayList<Crawling>();
+
+        String time = format.format(lateylyCrawlingTime);
 
         Integer site = CrawlingSite.YOUTUBE.getCode();
 
@@ -208,7 +211,7 @@ public class CrawlingServiceImpl implements CrawlingService {
                 .queryParam("key",  youtubeAccessKey)
                 .queryParam("maxResults", "50")
                 .queryParam("type", "video")
-                .queryParam("publishedAfter", now);
+                .queryParam("publishedAfter", time);
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(new MediaType("application", "json", Charset.forName("UTF-8")));

--- a/src/main/java/in/koala/serviceImpl/KeywordServiceImpl.java
+++ b/src/main/java/in/koala/serviceImpl/KeywordServiceImpl.java
@@ -195,8 +195,8 @@ public class KeywordServiceImpl implements KeywordService {
     }
 
     @Override
-    public void deletedNotice(String noticeId) {
-        keywordMapper.deleteNotice(noticeId);
+    public void deletedNotice(List<Integer> noticeList) {
+        keywordMapper.deleteNotice(noticeList);
     }
 
     @Override

--- a/src/main/resources/mapper/KeywordMapper.xml
+++ b/src/main/resources/mapper/KeywordMapper.xml
@@ -145,9 +145,13 @@
     </update>
 
     <update id="deleteNotice">
-        UPDATE notice
-        SET is_deleted = 1
-        WHERE id = #{noticeId}
+        <foreach collection="noticeList" index="index" separator=";" item="noticeId">
+            UPDATE notice
+            <set>
+                is_deleted = 1
+            </set>
+            WHERE id = #{noticeId}
+        </foreach>
     </update>
 
     <select id="searchKeyword" parameterType="java.lang.String" resultType="java.lang.String">


### PR DESCRIPTION
1. 키워드 - 알림 삭제 API 수정
 - 기존 notice-id는 하나만 등록 가능
 - 리스트 형태로 변형
 - notice-id 여러개 선택하여 삭제 가능
 
2. 유튜브 크롤링 오류 수정
 - 기존에는 현재 시간을 기준으로 데이터를 불러옴
 - 최근 크롤링 한 시간을 기준으로 데이터를 불러오도록 수정