### PR TITLE
Fix : 히스토리 알림 조회 및 키워드 삭제 오류 해결

### DIFF
--- a/src/main/java/in/koala/serviceImpl/KeywordPushServiceImpl.java
+++ b/src/main/java/in/koala/serviceImpl/KeywordPushServiceImpl.java
@@ -65,6 +65,7 @@ public class KeywordPushServiceImpl implements KeywordPushService {
             message.setCondition(sb.toString());
             System.out.println("최종 : "+ sb);
             fcmSender.sendMessage(message);
+            noticeMapper.insertNotice(value);
         }
     }
 

--- a/src/main/resources/mapper/HistoryMapper.xml
+++ b/src/main/resources/mapper/HistoryMapper.xml
@@ -3,7 +3,7 @@
 <mapper namespace="in.koala.mapper.HistoryMapper">
 
     <select id="getEveryNotice" resultType = "in.koala.domain.Notice">
-        SELECT n.id, c.site, c.title, c.url, c.created_at AS createdAt, n.is_read AS isRead
+        SELECT n.id, c.site, c.title, c.url, n.created_at AS createdAt, n.is_read AS isRead
         FROM notice AS n
                  INNER JOIN keyword AS k
                             ON k.id = n.keyword_id

--- a/src/main/resources/mapper/KeywordMapper.xml
+++ b/src/main/resources/mapper/KeywordMapper.xml
@@ -46,19 +46,21 @@
 
     <!--키워드 삭제 (지금은 멀티쿼리 사용중이나, join문 활용하여 삭제할수 있게 리팩토링 필요)-->
     <update id="deleteKeyword">
-        UPDATE keyword
-        SET is_deleted = 1
-        WHERE user_id = #{userId}
-            AND name = #{keywordName};
-
         UPDATE keyword_site
         SET is_deleted = 1
         WHERE keyword_id = (
-                SELECT id
-                FROM keyword
-                WHERE user_id = #{userId}
-                  AND name = #{keywordName}
-            );
+            SELECT id
+            FROM keyword
+            WHERE user_id = #{userId}
+              AND name = #{keywordName}
+              AND is_deleted = 0
+        );
+
+        UPDATE keyword
+        SET is_deleted = 1
+        WHERE user_id = #{userId}
+            AND name = #{keywordName}
+            AND is_deleted = 0;
     </update>
 
     <select id="getKeywordSite" resultType="in.koala.enums.CrawlingSite">
@@ -169,6 +171,7 @@
             FROM keyword
             WHERE user_id = #{userId}
               AND name = #{keywordName}
+              AND is_deleted = 0
         );
     </select>
 

--- a/src/main/resources/mapper/KeywordPushMapper.xml
+++ b/src/main/resources/mapper/KeywordPushMapper.xml
@@ -14,7 +14,7 @@
     </select>
 
     <select id="pushKeywordByLatelyCrawlingTime" resultType="java.util.Map">
-        SELECT k.name, c.title, c.url, c.site
+        SELECT k.id as keywordId, k.name, c.id as crawlingId, c.title, c.url, c.site
         from crawling as c
                  inner join keyword as k on c.title LIKE CONCAT('%',k.name,'%')
                  inner join keyword_site as ks ON k.id = ks.keyword_id and ks.site_name = c.site


### PR DESCRIPTION
1. Fix : 키워드 삭제 시 발생한 문제 해결(이전에 삭제했던 데이터 중복으로 인하여 다시 재 삭제 했을 경우 에러 발생 -> is_deleted=0 추가 후 해결)
2. [Fix : 알림 메시지 DB 저장 로직 수정]
3. [Fix : 히스토리 - 알림 조회 시 알림이 생성된 시간순으로 정렬]