### PR TITLE
Fix : 키워드 수정 시 nested exception is org.apache.ibatis.exceptions.TooMa…

### DIFF
--- a/src/main/resources/mapper/KeywordMapper.xml
+++ b/src/main/resources/mapper/KeywordMapper.xml
@@ -85,7 +85,8 @@
         SELECT id
         FROM keyword
         WHERE user_id = #{userId}
-            AND name = #{keywordName};
+            AND name = #{keywordName}
+            AND is_deleted = 0;
     </select>
 
     <update id="modifyKeywordSite">
@@ -111,6 +112,7 @@
                 FROM keyword
                 WHERE user_id = #{userId}
                 AND name = #{keywordName}
+                AND is_deleted = 0
             ) AS sub_table
         );
     </update>


### PR DESCRIPTION
키워드 수정 시, 아래와 같은 오류 발생
"className":"MyBatisSystemException","errorMessage":"nested exception is org.apache.ibatis.exceptions.TooManyResultsException: Expected one result (or null) to be returned by selectOne(), but found: 11","code":0,"errorTrace":"org.mybatis.spring.MyBatisExceptionTranslator.translateExceptionIfPossible(MyBatisExceptionTranslator.java:92)"

오류 위치 : Mapper에서 동일한 이름을 가지고 있으며 삭제된 키워드에 대해 조회가 이루어져 결과값이 2개 이상이 됨.
해결 방법 : is_deleted = 0 조건을 추가하여 삭제 되지 않은 키워드에 대해서 실행될 수 있도록 변경