### PR TITLE
Fix : 키워드 수정 시 nested exception is org.apache.ibatis.exceptions.TooMa…

### DIFF
--- a/src/main/java/in/koala/serviceImpl/KeywordServiceImpl.java
+++ b/src/main/java/in/koala/serviceImpl/KeywordServiceImpl.java
@@ -89,7 +89,7 @@ public class KeywordServiceImpl implements KeywordService {
     public Boolean modifyKeyword(String keywordName, Keyword keyword) throws Exception {
 
         Long userId = getLoginUserInfo().getId();
-
+        keyword.setUserId(userId);
         checkDuplicateUsersKeyword(keyword);
 
         Set<CrawlingSite> addingList = new HashSet<>(keyword.getSiteList());

--- a/src/main/resources/mapper/KeywordMapper.xml
+++ b/src/main/resources/mapper/KeywordMapper.xml
@@ -27,7 +27,7 @@
     <select id="checkDuplicateUsersKeyword" parameterType="in.koala.domain.Keyword" resultType="java.lang.Long">
         SELECT id
         FROM keyword
-        WHERE user_id = #{userId} AND name = #{name} AND is_deleted = 0
+        WHERE user_id = #{userId} AND name = #{name} AND is_deleted = 0;
     </select>
 
     <!--키워드 등록 (2. 키워드 등록)-->


### PR DESCRIPTION
키워드 수정 시, 아래와 같은 오류 발생
nested exception is org.apache.ibatis.exceptions.TooManyResultsException: Expected one result (or null) to be returned by selectOne(), but found: 

오류 위치 : 키워드 삭제 및 상세 조회 시 문제가 발생 됨

해결 방법 : 키워드 수정 후, 키워드 삭제 및 상세 조회 시 문제가 발생 되어서 확인 해본 결과 키워드 수정 로직에서 중복검사에서 문제가 발생함, keyword.setUserId(userId) 추가하여 해결 완료