### PR TITLE
Fix : Swagger 오타 수정 & 키워드 수정 시, 키워드 이름이 동일할 경우 중복 처리되는 현상 수정

### DIFF
--- a/src/main/java/in/koala/controller/HistoryController.java
+++ b/src/main/java/in/koala/controller/HistoryController.java
@@ -58,7 +58,7 @@ public class HistoryController {
     @Xss
     @Auth
     @ApiOperation(value = "히스토리 알림 읽음", notes = "사용자가 받은 알림에 대한 전체 내역에서 알림 읽음", authorizations = @Authorization(value = "Bearer +accessToken"))
-    @PutMapping(value = "/history{notice-id}")
+    @PutMapping(value = "/history/{notice-id}")
     public ResponseEntity noticeRead(@PathVariable(name = "notice-id") String noticeId){
         if(historyService.noticeRead(noticeId))
             return new ResponseEntity(BaseResponse.of("알림을 읽었습니다.",  HttpStatus.OK), HttpStatus.OK);

--- a/src/main/java/in/koala/domain/Keyword.java
+++ b/src/main/java/in/koala/domain/Keyword.java
@@ -60,8 +60,8 @@ public class Keyword {
 
     //알림 주기
     @NotNull(message = "알림 주기는 비워둘 수 없습니다.")
-    @Min(value = 5, message = "최소 알림 주기는 15분 입니다.")
-    @Max(value = 360, message = "최대 알림 주기는 4시간 입니다.")
+    @Min(value = 5, message = "최소 알림 주기는 5분 입니다.")
+    @Max(value = 360, message = "최대 알림 주기는 360시간 입니다.")
     private Integer alarmCycle;
 
     //읽지 않은 알림 숫자

--- a/src/main/java/in/koala/serviceImpl/KeywordServiceImpl.java
+++ b/src/main/java/in/koala/serviceImpl/KeywordServiceImpl.java
@@ -89,8 +89,11 @@ public class KeywordServiceImpl implements KeywordService {
     public Boolean modifyKeyword(String keywordName, Keyword keyword) throws Exception {
 
         Long userId = getLoginUserInfo().getId();
-        keyword.setUserId(userId);
-        checkDuplicateUsersKeyword(keyword);
+
+        if(!checkSameKeywordName(keywordName, keyword.getName())){
+            keyword.setUserId(userId);
+            checkDuplicateUsersKeyword(keyword);
+        }
 
         Set<CrawlingSite> addingList = new HashSet<>(keyword.getSiteList());
         Set<CrawlingSite> addingListCopy = copySiteList(addingList);
@@ -296,5 +299,9 @@ public class KeywordServiceImpl implements KeywordService {
             pageNumber = (pageNumber-1) * 20;
         }
         return pageNumber;
+    }
+
+    private Boolean checkSameKeywordName(String existingKeywordName, String newKeywordName){
+        return existingKeywordName.equals(newKeywordName);
     }
 }


### PR DESCRIPTION
키워드 수정 시, 아래와 같은 오류 발생

키워드 수정 단계에서 이름이 동일한데 키워드에 대한 정보만 변경할 경우, <중복된 키워드 입니다.> 예외 발생 됨

오류 위치 : KeywordServiceImpl.modifyKeyword()

해결 방법 : 수정하고자하는 키워드 이름(keywordName) 과 수정한 키워드의 이름(keyword.getName())이 동일하지 않은 경우에만 이름 중복 검사 실행 / 동일할 경우에는 미 실시