### PR TITLE
Fix : 키워드 목록 페이지 - 전체 및 구독하는 사이트별로 조회 수정

### DIFF
--- a/src/main/resources/mapper/KeywordMapper.xml
+++ b/src/main/resources/mapper/KeywordMapper.xml
@@ -126,6 +126,7 @@
         ON k.id = n.keyword_id
         WHERE k.name = #{keywordName}
         AND k.user_id = #{userId}
+        AND k.is_deleted = 0
         AND n.is_deleted = 0
         <if test="site != null">
             AND site = #{site}


### PR DESCRIPTION
# 개요
* 키워드의 구독하는 사이트에 대한 알림이 새로 생성된 키워드에 대해 반환되는 현상 발생

# 발생 이유
* KeywordMapper에서 선택한 키워드에 대해 알림을 불러오는 과정에서 삭제되었다는 조건인 is_deleted=0이 빠짐

# 해결 방안
 * 삭제된 키워드의 알림이 조회되지 않도록 keyword.is_deleted=0 조건 추가