### PR TITLE
Fixes : "히스토리 조회시 크롤링 데이터에 대한 고유 ID 값 추가 반환"

### DIFF
--- a/src/main/java/in/koala/domain/Notice.java
+++ b/src/main/java/in/koala/domain/Notice.java
@@ -14,6 +14,8 @@ public class Notice{
     private String createdAt;
     private Boolean isRead;
 
+    private Long crawlingId;
+
     public Notice(Long id, String site, String title, String url, String createdAt){
         this.id = id;
         this.site = site;

--- a/src/main/resources/mapper/HistoryMapper.xml
+++ b/src/main/resources/mapper/HistoryMapper.xml
@@ -3,7 +3,7 @@
 <mapper namespace="in.koala.mapper.HistoryMapper">
 
     <select id="getEveryNotice" resultType = "in.koala.domain.Notice">
-        SELECT n.id, c.site, c.title, c.url, n.created_at AS createdAt, n.is_read AS isRead
+        SELECT n.id, c.site, c.title, c.url, n.created_at AS createdAt, n.is_read AS isRead, c.id as crawlingId
         FROM notice AS n
                  INNER JOIN keyword AS k
                             ON k.id = n.keyword_id


### PR DESCRIPTION
기존에는 알림에 대한 정보만을 보냈습니다.
하지만 히스토리에서 보관함으로 보내는 과정에서 crawlingId 값이 필요하기에 해당 부분을 추가했습니다.