### PR TITLE
Fix : "알림 발생 시, 빈 리스트에 대해서는 DB 접근하지 않게 하기"

### DIFF
--- a/src/main/java/in/koala/util/Scheduler.java
+++ b/src/main/java/in/koala/util/Scheduler.java
@@ -37,7 +37,8 @@ public class Scheduler {
             keywordPushService.pushNotification(notice.getTokenList(), notice.getKeyword(),
                     notice.getSite(), notice.getUrl());
         }
-        noticeService.insertNotice(pushNoticeList);
+        if(!pushNoticeList.isEmpty())
+            noticeService.insertNotice(pushNoticeList);
     }
     /**
      1초에 한번씩 호출하는 cron expression


### PR DESCRIPTION
알림 발생 시, 알림 리스트들을 DB에 저장하게 되는데, 빈 리스트인 경우에는 DB에 접근하지 않도록 수정